### PR TITLE
The auth and cfg commands all use the renderer now.

### DIFF
--- a/etrade/cmd/cmd_auth.go
+++ b/etrade/cmd/cmd_auth.go
@@ -5,7 +5,7 @@ import (
 )
 
 type CommandAuth struct {
-	context CommandContext
+	context CommandContextWithStore
 }
 
 func (c *CommandAuth) Command(globalFlags *globalFlags) *cobra.Command {
@@ -14,7 +14,7 @@ func (c *CommandAuth) Command(globalFlags *globalFlags) *cobra.Command {
 		Short: "Authentication actions",
 		Long:  "Authentication actions",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			context, err := NewCommandContextFromFlags(globalFlags)
+			context, err := NewCommandContextWithStoreFromFlags(globalFlags)
 			if err != nil {
 				return err
 			}

--- a/etrade/cmd/cmd_auth_clear.go
+++ b/etrade/cmd/cmd_auth_clear.go
@@ -2,12 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/jerryryle/etrade-cli/pkg/etradelib/jsonmap"
 	"github.com/spf13/cobra"
 	"os"
 )
 
 type CommandAuthClear struct {
-	Context *CommandContext
+	Context *CommandContextWithStore
 }
 
 func (c *CommandAuthClear) Command() *cobra.Command {
@@ -43,6 +44,24 @@ func (c *CommandAuthClear) ClearAuth(customerId string) error {
 			return fmt.Errorf("unable to remove auth cache for %s (%w)", customerId, err)
 		}
 	}
-	fmt.Println("Done!")
+
+	resultMap := jsonmap.JsonMap{
+		"status": "success",
+	}
+
+	if err := c.Context.Renderer.Render(resultMap, clearAuthDescriptor); err != nil {
+		return err
+	}
 	return nil
+}
+
+var clearAuthDescriptor = []RenderDescriptor{
+	{
+		ObjectPath: "",
+		Values: []RenderValue{
+			{Header: "Status", Path: ".status"},
+		},
+		DefaultValue: "",
+		SpaceAfter:   false,
+	},
 }

--- a/etrade/cmd/cmd_cfg.go
+++ b/etrade/cmd/cmd_cfg.go
@@ -5,7 +5,6 @@ import (
 )
 
 type CommandCfg struct {
-	context CommandContext
 }
 
 func (c *CommandCfg) Command(globalFlags *globalFlags) *cobra.Command {
@@ -13,20 +12,9 @@ func (c *CommandCfg) Command(globalFlags *globalFlags) *cobra.Command {
 		Use:   "cfg",
 		Short: "Configuration actions",
 		Long:  "View or create configuration",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			context, err := NewCommandContextFromFlags(globalFlags)
-			if err != nil {
-				return err
-			}
-			c.context = *context
-			return nil
-		},
-		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
-			return c.context.Close()
-		},
 	}
 	// Add Subcommands
-	cmd.AddCommand((&CommandCfgList{Context: &c.context}).Command())
-	cmd.AddCommand((&CommandCfgCreate{Context: &c.context}).Command())
+	cmd.AddCommand((&CommandCfgList{}).Command(globalFlags))
+	cmd.AddCommand((&CommandCfgCreate{}).Command(globalFlags))
 	return cmd
 }

--- a/etrade/cmd/cmd_cfg_list.go
+++ b/etrade/cmd/cmd_cfg_list.go
@@ -1,21 +1,30 @@
 package cmd
 
 import (
-	"fmt"
+	"github.com/jerryryle/etrade-cli/pkg/etradelib/jsonmap"
 	"github.com/spf13/cobra"
-	"os"
-	"text/tabwriter"
 )
 
 type CommandCfgList struct {
-	Context *CommandContext
+	context CommandContextWithStore
 }
 
-func (c *CommandCfgList) Command() *cobra.Command {
+func (c *CommandCfgList) Command(globalFlags *globalFlags) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List configuration",
 		Long:  "List all available customers in the app configuration",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			context, err := NewCommandContextWithStoreFromFlags(globalFlags)
+			if err != nil {
+				return err
+			}
+			c.context = *context
+			return nil
+		},
+		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			return c.context.Close()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return c.ListConfig()
 		},
@@ -24,17 +33,39 @@ func (c *CommandCfgList) Command() *cobra.Command {
 }
 
 func (c *CommandCfgList) ListConfig() error {
-	w := tabwriter.NewWriter(os.Stdout, 1, 0, 4, ' ', 0)
-	_, _ = fmt.Fprintln(w, "Customer Id\tCustomer Name\tProduction Access")
-	_, _ = fmt.Fprintln(w, "-----------\t-------------\t-----------------")
-
-	for customerId, customerConfig := range c.Context.CustomerConfigurationStore.GetAllConfigurations() {
-		_, _ = fmt.Fprintf(
-			w,
-			"%s\t%s\t%t\n", customerId, customerConfig.CustomerName, customerConfig.CustomerProduction,
-		)
+	customerSlice := jsonmap.JsonSlice{}
+	for customerId, customerConfig := range c.context.CustomerConfigurationStore.GetAllConfigurations() {
+		customerMap := jsonmap.JsonMap{}
+		if err := customerMap.SetString("customerId", customerId); err != nil {
+			return err
+		}
+		if err := customerMap.SetString("customerName", customerConfig.CustomerName); err != nil {
+			return err
+		}
+		if err := customerMap.SetBool("productionAccess", customerConfig.CustomerProduction); err != nil {
+			return err
+		}
+		customerSlice = append(customerSlice, customerMap)
 	}
 
-	_ = w.Flush()
+	resultMap := jsonmap.JsonMap{
+		"customers": customerSlice,
+	}
+	if err := c.context.Renderer.Render(resultMap, cfgListDescriptor); err != nil {
+		return err
+	}
 	return nil
+}
+
+var cfgListDescriptor = []RenderDescriptor{
+	{
+		ObjectPath: ".customers",
+		Values: []RenderValue{
+			{Header: "Customer Id", Path: ".customerId"},
+			{Header: "Customer Name", Path: ".customerName"},
+			{Header: "Production Access", Path: ".productionAccess"},
+		},
+		DefaultValue: "",
+		SpaceAfter:   false,
+	},
 }


### PR DESCRIPTION
Needed to further refactor the command context for the "cfg create" command.