### PR TITLE
Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 
 install:
 	@printf "Installing to: "
-	@go list -f '{{.Target}}' ./etrade
+	@go list -C ./etrade -f '{{.Target}}'
 	@go install -ldflags "-s -w" ./etrade
 	@echo "Done!"
 

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 all: test build
 
 test:
-        go test ./...
+	go test ./...
 
 build:
-        go build -C ./etrade
+	go build -C ./etrade
 
 install:
-        @printf "Installing to: "
-        @go list -f '{{.Target}}' ./etrade
-        @go install -ldflags "-s -w" ./etrade
-        @echo "Done!"
+	@printf "Installing to: "
+	@go list -f '{{.Target}}' ./etrade
+	@go install -ldflags "-s -w" ./etrade
+	@echo "Done!"
 
 clean:
-        go clean
-        rm -f ./etrade/etrade
+	go clean
+	rm -f ./etrade/etrade

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 all: test build
 
 test:
-	go test ./...
+        go test ./...
 
 build:
-	go build -C ./etrade
+        go build -C ./etrade
 
 install:
-	@printf "Installing to: "
-	@go list -f '{{.Target}}' -C ./etrade
-	@go install -ldflags "-s -w" ./etrade
-	@echo "Done!"
+        @printf "Installing to: "
+        @go list -f '{{.Target}}' ./etrade
+        @go install -ldflags "-s -w" ./etrade
+        @echo "Done!"
 
 clean:
-	go clean
-	rm -f ./etrade/etrade
+        go clean
+        rm -f ./etrade/etrade


### PR DESCRIPTION
* When running `make install`, I got this error:

      Installing to: invalid value "./etrade" for flag -C: -C flag must be first flag on command line
      usage: go list [-f format] [-json] [-m] [list flags] [build flags] [packages]
      Run 'go help list' for details.
      make: *** [Makefile:11: install] Error 2

* I ran 'go help list' but the -C flag was undocumented.
* I tried moving the -C flag to the first position after "go list", but I got this error:

      Installing to: go: chdir -f: no such file or directory
      make: *** [Makefile:11: install] Error 1

* I ultimately resolved the error by removing the -C flag. `make install` now runs successfully.